### PR TITLE
Don't show the settings window when the app is relaunched

### DIFF
--- a/CenterMouse/Sources/AppDelegate.swift
+++ b/CenterMouse/Sources/AppDelegate.swift
@@ -10,6 +10,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	private var eventMonitor = EventMonitor()
 
+	/// Whether or not the app is relaunching after it has been launched and quit before
+	///
+	/// We track this to know whether or not to open the Settings window. If this is a
+	/// fresh relaunch, we _don't_ want to open the Settings window right away.
+	private var isRelaunch = false
+
+	func applicationWillFinishLaunching(_ notification: Notification) {
+		if Defaults[.firstTimeAppLaunched] {
+			Defaults[.firstTimeAppLaunched] = false
+		} else {
+			isRelaunch = true
+		}
+	}
+
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		window = NSWindow(
 			contentRect: NSZeroRect,
@@ -21,10 +35,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		window.title = "CenterMouse"
 		window.contentView = NSHostingView(rootView: SettingsView())
 		windowController = NSWindowController(window: window)
-
-		Settings.setActivationPolicy()
-
-		openSettingsWindow()
 	}
 
 	func applicationDidBecomeActive(_ notification: Notification) {
@@ -46,6 +56,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		guard
 			ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1"
 		else {
+			return
+		}
+
+		// We only need to check whether this is a relaunch the first time this method
+		// is called (by `applicationDidBecomeActive(_:)`). After that, we'll want to
+		// open the Settings window whenever this method is called, so we set the value
+		// to `false`.
+		guard isRelaunch == false else {
+			isRelaunch = false
 			return
 		}
 

--- a/CenterMouse/Sources/Settings.swift
+++ b/CenterMouse/Sources/Settings.swift
@@ -4,6 +4,7 @@ import Defaults
 extension Defaults.Keys {
 	static let hideDockIcon = Key<Bool>("hideDockIcon", default: false)
 	static let monitorSystemEvents = Key<Bool>("monitorSystemEvents", default: true)
+	static let firstTimeAppLaunched = Key<Bool>("firstTimeAppLaunched", default: true)
 }
 
 enum Settings {


### PR DESCRIPTION
Resolves #3

## Summary

This pull request ensures that the settings window does not open automatically upon relaunching the app. This gets around the annoying behavior when the app is set to launch at login.

## Changes

- Updates app startup process to not show the settings window when relaunching, but still show it if it is the first time ever launching the app